### PR TITLE
fixed up dependencies to match jStyleParser repo

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -7,7 +7,6 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry combineaccessrules="false" exported="true" kind="src" path="/CSSParser"/>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
 		<attributes>
 			<attribute name="optional" value="true"/>

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
 		<dependency>
 			<groupId>net.sf.cssbox</groupId>
 			<artifactId>jstyleparser</artifactId>
-			<version>1.20</version>
+			<version>1.21-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
The pom and classpath files didn't match the current jStyleParser repo. I've updated them locally, but it seems like helpful changes for others as well.