### PR TITLE
Fixed resizing of images

### DIFF
--- a/src/main/java/org/fit/cssbox/layout/CSSDecoder.java
+++ b/src/main/java/org/fit/cssbox/layout/CSSDecoder.java
@@ -154,14 +154,20 @@ public class CSSDecoder
         int atrw = -1;
         int atrh = -1;
         try {
-            if (!HTMLNorm.getAttribute(el, "width").equals(""))
+            if (!HTMLNorm.getAttribute(el, "width").equals("")) {
                 atrw = HTMLNorm.computeAttributeLength(HTMLNorm.getAttribute(el, "width"), twidth);
+            } else {
+                atrw = twidth;
+            }
         } catch (NumberFormatException e) {
             log.info("Invalid width value: " + HTMLNorm.getAttribute(el, "width"));
         }
         try {
-            if (!HTMLNorm.getAttribute(el, "height").equals(""))
+            if (!HTMLNorm.getAttribute(el, "height").equals("")) {
                 atrh = HTMLNorm.computeAttributeLength(HTMLNorm.getAttribute(el, "height"), theight);
+            } else {
+                atrh = theight;
+            }
         } catch (NumberFormatException e) {
             log.info("Invalid height value: " + HTMLNorm.getAttribute(el, "width"));
         }


### PR DESCRIPTION
If an image is loaded and its bigger than its bounding box, make sure it
gets the right size even if the dimensions of the are given only by its
parent.