### PR TITLE
permit external URL resolution for images

### DIFF
--- a/src/main/java/org/fit/cssbox/io/URLResolver.java
+++ b/src/main/java/org/fit/cssbox/io/URLResolver.java
@@ -1,0 +1,31 @@
+/**
+ * DOMSource.java
+ * Copyright (c) 2005-2007 Radek Burget
+ *
+ * CSSBox is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CSSBox is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with CSSBox. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Created on 08.03.2017, 10:02:15 by danlobo
+ */
+
+package org.fit.cssbox.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+public class URLResolver {
+    public InputStream resolve(URL url) throws IOException {
+        return url.openStream();
+    }
+}

--- a/src/main/java/org/fit/cssbox/layout/BrowserConfig.java
+++ b/src/main/java/org/fit/cssbox/layout/BrowserConfig.java
@@ -24,10 +24,7 @@ import java.awt.Font;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.fit.cssbox.io.DOMSource;
-import org.fit.cssbox.io.DefaultDOMSource;
-import org.fit.cssbox.io.DefaultDocumentSource;
-import org.fit.cssbox.io.DocumentSource;
+import org.fit.cssbox.io.*;
 
 /**
  * A rendering engine configuration.
@@ -65,6 +62,9 @@ public class BrowserConfig
     
     /** Default font families */
     private Map<String, String> defaultFonts;
+
+    /* Default URL resolver */
+    private URLResolver urlResolver;
     
     /**
      * Creates a new config with default values of the options.
@@ -80,6 +80,7 @@ public class BrowserConfig
         clipViewport = false;
         documentSourceClass = DefaultDocumentSource.class;
         domSourceClass = DefaultDOMSource.class;
+        urlResolver = new URLResolver();
         initDefaultFonts();
     }
 
@@ -246,7 +247,18 @@ public class BrowserConfig
     {
         return defaultFonts.get(logical);
     }
-    
+
+    /** Obtains the class used by CSSBox to obtain data from external URLs
+     * @return the used class
+     */
+    public URLResolver getUrlResolver() {  return this.urlResolver; }
+
+    /**
+     * Sets a URL resolver for external URLs
+     * @param value the URL resolver
+     */
+    public void setUrlResolver(URLResolver value) { this.urlResolver = value; }
+
     /**
      * Initializes the default fonts. Current implementation just defines the same physical names for basic
      * AWT logical fonts.

--- a/src/main/java/org/fit/cssbox/layout/ContentImage.java
+++ b/src/main/java/org/fit/cssbox/layout/ContentImage.java
@@ -36,6 +36,7 @@ import javax.imageio.ImageReader;
 import javax.imageio.event.IIOReadUpdateListener;
 import javax.imageio.stream.ImageInputStream;
 
+import org.fit.cssbox.io.URLResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,6 +70,7 @@ public abstract class ContentImage extends ReplacedContent implements ImageObser
     protected Toolkit toolkit; //system default toolkit
     protected boolean abort; //error or abort flag during loading in image observer
     protected boolean complete; //set to true when image loading is complete
+    protected URLResolver urlResolver; //used to get the image URL contents
     
     public ContentImage(ElementBox owner)
     {
@@ -81,6 +83,7 @@ public abstract class ContentImage extends ReplacedContent implements ImageObser
         this.abort = false;
         this.complete = false;
         this.loadTimeout = owner.getViewport().getConfig().getImageLoadTimeout();
+        this.urlResolver = owner.getViewport().getConfig().getUrlResolver();
     }
 
     /**
@@ -172,7 +175,7 @@ public abstract class ContentImage extends ReplacedContent implements ImageObser
     {
         Image image = null;
         InputStream urlStream = null;
-        urlStream = url.openStream();
+        urlStream = this.urlResolver.resolve(url);
         ImageInputStream imageInputStream = ImageIO.createImageInputStream(urlStream);
         try
         {


### PR DESCRIPTION
The actual code uses the `url.openStream()`, which doesn't give too much options to control how to obtain the image (from a local file, for example). This change allows the user to manipulate how to load URL images. The requirement is to create a subclass of `URLResolver` and its `resolve` method, returning the actual `InputStream` from the given url.

The `URLResolver` instance is found as a `BrowserConfig`'s property.