### PR TITLE
Customization for ImageCache needed

### DIFF
--- a/src/main/java/org/fit/cssbox/layout/BrowserConfig.java
+++ b/src/main/java/org/fit/cssbox/layout/BrowserConfig.java
@@ -73,6 +73,8 @@ public class BrowserConfig
     
     /** Registered content observer that tracks the image loading */
     private ContentObserver contentObserver;
+
+    private ImageCache imageCache;
     
     /** Default font families */
     private Map<String, String> defaultFonts;
@@ -165,6 +167,15 @@ public class BrowserConfig
     public ContentObserver getContentObserver()
     {
         return contentObserver;
+    }
+
+    public ImageCache getImageCache()
+    {
+        return imageCache;
+    }
+
+    public void setImageCache(ImageCache imageCache) {
+        this.imageCache = imageCache;
     }
 
     public boolean getUseHTML()

--- a/src/main/java/org/fit/cssbox/layout/ContentImage.java
+++ b/src/main/java/org/fit/cssbox/layout/ContentImage.java
@@ -132,79 +132,85 @@ public abstract class ContentImage extends ReplacedContent implements ImageObser
         Image img;
         if (url != null)
         {
-            if (cache)
+            ImageCache imageCache = getImageCache(cache);
+            if (imageCache != null)
             {
                 // get image and cache
-                img = ImageCache.get(url);
-                if (img == null && !ImageCache.hasFailed(url)) {
-                    try {
-                        img = loadImageFromSource(url);
-                    } catch (IOException e) {
-                        observeLoadFailed(url);
-                        ImageCache.putFailed(url);
-                        log.error("Unable to get image from: " + url);
-                        log.error(e.getMessage());
-                        return null;
-                    }
+                img = imageCache.get(url);
+                if (img == null && !imageCache.hasFailed(url)) {
+                    img = loadImageFromSource(url);
                     if (img != null)
-                        ImageCache.put(url, img);
+                        imageCache.put(url, img);
                     else
-                        ImageCache.putFailed(url);
+                        imageCache.putFailed(url);
                 }
             }
             else
             {
                 // do not cache, just get image
-                try {
-                    img = loadImageFromSource(url);
-                } catch (IOException e) {
-                    observeLoadFailed(url);
-                    log.error("Unable to get image from: " + url);
-                    log.error(e.getMessage());
-                    return null;
-                }
+                img = loadImageFromSource(url);
             }
 
-            // start loading and preparation
-            toolkit.prepareImage(img, -1, -1, observer);
-            return img;
+            if(img != null)
+            {
+                // start loading and preparation
+                toolkit.prepareImage(img, -1, -1, observer);
+                return img;
+            }
+            // observer need to know that resource with this url will be absent.
+            // Even if we only check that url has failed earlier.
+            observeLoadFailed(url);
         }
         return null;
     }
 
-    private Image loadImageFromSource(URL url) throws IOException
+    private ImageCache getImageCache(boolean cache)
+    {
+        return cache ? getOwner().getViewport().getConfig().getImageCache() : null;
+    }
+
+    private Image loadImageFromSource(URL url)
     {
         Image image = null;
-        DocumentSource imgsrc = owner.getViewport().getConfig().createDocumentSource(url);
-        InputStream urlStream = imgsrc.getInputStream();
-        ImageInputStream imageInputStream = ImageIO.createImageInputStream(urlStream);
-        try
-        {
-            Iterator<ImageReader> imageReaders = ImageIO.getImageReaders(imageInputStream);
-            if (!imageReaders.hasNext())
-            {
-                log.warn("No image readers for URL: " + url);
-                log.warn("  owner: " + getOwner());
-            }
-            while (imageReaders.hasNext())
-            {
-                ImageReader currentImageReader = imageReaders.next();
-                currentImageReader.setInput(imageInputStream);
-                currentImageReader.addIIOReadUpdateListener(this);
 
-                try
+        // I need to catch IOExceptions starting from this moment and close imgsrc if set
+        try (DocumentSource imgsrc = owner.getViewport().getConfig().createDocumentSource(url))
+        {
+            InputStream urlStream = imgsrc.getInputStream();
+            ImageInputStream imageInputStream = ImageIO.createImageInputStream(urlStream);
+            try
+            {
+                Iterator<ImageReader> imageReaders = ImageIO.getImageReaders(imageInputStream);
+                if (!imageReaders.hasNext())
                 {
-                    image = currentImageReader.read(0);
-                } catch (Exception e) {
-                    log.error("Image decoding error: " + e.getMessage() + " with reader " + currentImageReader);
-                } finally {
-                    currentImageReader.dispose();
+                    log.warn("No image readers for URL: " + url);
+                    log.warn("  owner: " + getOwner());
                 }
+                else
+                {
+                    do
+                    {
+                        ImageReader currentImageReader = imageReaders.next();
+                        currentImageReader.setInput(imageInputStream);
+                        currentImageReader.addIIOReadUpdateListener(this);
+
+                        try
+                        {
+                            image = currentImageReader.read(0);
+                        } catch (Exception e) {
+                            log.error("Image decoding error: " + e.getMessage() + " with reader " + currentImageReader);
+                        } finally {
+                            currentImageReader.dispose();
+                        }
+                    }
+                    while (imageReaders.hasNext());
+                }
+            } catch (Exception e) {
+                log.error("Image decoding error: " + e.getMessage());
             }
-        } catch (Exception e) {
-            log.error("Image decoding error: " + e.getMessage());
-        } finally {
-            imgsrc.close();
+        } catch (IOException e) {
+            log.error("Unable to get image from: " + url);
+            log.error(e.getMessage());
         }
 
         return image;

--- a/src/main/java/org/fit/cssbox/layout/ContentImage.java
+++ b/src/main/java/org/fit/cssbox/layout/ContentImage.java
@@ -203,7 +203,7 @@ public abstract class ContentImage extends ReplacedContent implements ImageObser
                             currentImageReader.dispose();
                         }
                     }
-                    while (imageReaders.hasNext());
+                    while (image == null && imageReaders.hasNext());
                 }
             } catch (Exception e) {
                 log.error("Image decoding error: " + e.getMessage());

--- a/src/main/java/org/fit/cssbox/layout/ImageCache.java
+++ b/src/main/java/org/fit/cssbox/layout/ImageCache.java
@@ -21,49 +21,17 @@ package org.fit.cssbox.layout;
 
 import java.awt.Image;
 import java.net.URL;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * A simple cache for storing already loaded images.
+ * Image cache interface. Simple singleton implementation is not enough.
+ * For example we can try to load failed image later, set some limits to memory storage or store them on local FS.
  * 
- * @author Alessandro Tucci
+ * @author dedrakot
  */
-public class ImageCache
+public interface ImageCache
 {
-    private static ConcurrentHashMap<URL, Image> cache;
-    static {
-        cache = new ConcurrentHashMap<URL, Image>();
-    }
-
-    private static ConcurrentHashMap<URL, Boolean> failed;
-    static {
-        failed = new ConcurrentHashMap<URL, Boolean>();
-    }
-    
-    public static Image put(URL uri, Image image)
-    {
-        return cache.put(uri, image);
-    }
-
-    public static Image get(URL uri)
-    {
-        return cache.get(uri);
-    }
-
-    public static Image remove(URL uri)
-    {
-        return cache.remove(uri);
-    }
-    
-    public static void putFailed(URL uri)
-    {
-        failed.put(uri, true);
-    }
-    
-    public static boolean hasFailed(URL uri)
-    {
-        Boolean b = failed.get(uri);
-        return (b != null && b == true);
-    }
-    
+    void put(URL uri, Image image);
+    Image get(URL uri);
+    void putFailed(URL uri);
+    boolean hasFailed(URL uri);
 }

--- a/src/main/java/org/fit/cssbox/layout/UnlimitedImageCache.java
+++ b/src/main/java/org/fit/cssbox/layout/UnlimitedImageCache.java
@@ -1,0 +1,49 @@
+package org.fit.cssbox.layout;
+
+import java.awt.*;
+import java.net.URL;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Implementation with unlimited storage size.
+ *
+ * @author dedrakot. Based on Alessandro Tucci simple cache for storing already loaded images.
+ */
+public class UnlimitedImageCache implements ImageCache
+{
+    private static ConcurrentHashMap<URL, Image> cache;
+
+    static {
+        cache = new ConcurrentHashMap<>();
+    }
+
+    private static ConcurrentHashMap<URL, Boolean> failed;
+
+    static {
+        failed = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public void put(URL uri, Image image)
+    {
+        cache.put(uri, image);
+    }
+
+    @Override
+    public Image get(URL uri)
+    {
+        return cache.get(uri);
+    }
+
+    @Override
+    public void putFailed(URL uri)
+    {
+        failed.put(uri, Boolean.TRUE);
+    }
+
+    @Override
+    public boolean hasFailed(URL uri)
+    {
+        return failed.get(uri) != null;
+    }
+}


### PR DESCRIPTION
For long running application it is critical to have possibility to limit cache size or reload failed urls after some time. Add only old unlimited implementation because don't want to add some external dependencies. 
Right now I am using simple guava implementation. I can upload code if you intrested in. It's pretty the asme but failed urls stored in cache made with CacheBuilder.expireAfterWrite, base cache has limits based on number of images or on total size (CacheBuilder.maximumSize(size) or CacheBuilder.maximumWeight(weight).weigher(wegher))