### PR TITLE
Fix javadoc on VisualContext#fontAvailable()

### DIFF
--- a/src/main/java/org/fit/cssbox/layout/VisualContext.java
+++ b/src/main/java/org/fit/cssbox/layout/VisualContext.java
@@ -737,7 +737,8 @@ public abstract class VisualContext
     }
     
     /** 
-     * Returns true if the font family is available.
+     * Find the font family available with the given family name, bold and italic properties,
+     * or return {@code null} if the font is not available
      * @return The exact name of the font family or {@code null} if the font is not available
      */
     protected abstract String fontAvailable(String family, boolean isBold, boolean isItalic);


### PR DESCRIPTION
Thank you so much for building and sharing CSSbox!

In the process of making a custom Engine I found a small javadoc typo in VisualContext#fontAvailable(). I'm not sure if this is what it actually means but it doesn't return a boolean.