### PR TITLE
Update NekoHTML dependency to v.2.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,9 +145,9 @@
 	
 	<dependencies>
 		<dependency>
-			<groupId>net.sourceforge.nekohtml</groupId>
+			<groupId>org.codelibs</groupId>
 			<artifactId>nekohtml</artifactId>
-			<version>1.9.22</version>
+			<version>2.0.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/src/main/java/org/fit/cssbox/io/DefaultDOMSource.java
+++ b/src/main/java/org/fit/cssbox/io/DefaultDOMSource.java
@@ -22,8 +22,8 @@ package org.fit.cssbox.io;
 import java.io.IOException;
 
 import org.apache.xerces.parsers.DOMParser;
-import org.cyberneko.html.HTMLConfiguration;
-import org.cyberneko.html.HTMLElements;
+import org.codelibs.nekohtml.HTMLConfiguration;
+import org.codelibs.nekohtml.HTMLElements;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 


### PR DESCRIPTION
Update to NekoHTML library v.2.0.2 due to discovered security vulnerabilities with NekoHTML library v.1.9.22. Black Duck scanning v.2.0.2 shows no known security vulnerabilities up to this day. 
We are using CSSBox library as one of our dependencies for printing the html documents and recently there was a vulnerability discovered with it's dependency library NekoHTML. This fix would enable us to continue using the CSSBox library.