### PR TITLE
security: avoid CVE-2022-28366 and CVE-2022-28366 / use org.htmlunit:neko-htmlunit@3.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,9 +145,9 @@
 	
 	<dependencies>
 		<dependency>
-			<groupId>org.codelibs</groupId>
-			<artifactId>nekohtml</artifactId>
-			<version>2.0.2</version>
+			<groupId>org.htmlunit</groupId>
+			<artifactId>neko-htmlunit</artifactId>
+			<version>3.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
 		<dependency>
 			<groupId>org.htmlunit</groupId>
 			<artifactId>neko-htmlunit</artifactId>
-			<version>3.0.0</version>
+			<version>3.6.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/src/main/java/org/fit/cssbox/io/DefaultDOMSource.java
+++ b/src/main/java/org/fit/cssbox/io/DefaultDOMSource.java
@@ -41,7 +41,7 @@ public class DefaultDOMSource extends DOMSource
     @Override
     public Document parse() throws SAXException, IOException
     {
-        DOMParser parser = new DOMParser(new HTMLConfiguration());
+        DOMParser parser = new DOMParser(HTMLDocumentImpl.class);
         parser.setProperty("http://cyberneko.org/html/properties/names/elems", "lower");
         if (charset != null)
             parser.setProperty("http://cyberneko.org/html/properties/default-encoding", charset);

--- a/src/main/java/org/fit/cssbox/io/DefaultDOMSource.java
+++ b/src/main/java/org/fit/cssbox/io/DefaultDOMSource.java
@@ -21,9 +21,8 @@ package org.fit.cssbox.io;
 
 import java.io.IOException;
 
-import org.apache.xerces.parsers.DOMParser;
-import org.codelibs.nekohtml.HTMLConfiguration;
-import org.codelibs.nekohtml.HTMLElements;
+import org.htmlunit.cyberneko.html.dom.HTMLDocumentImpl;
+import org.htmlunit.cyberneko.parsers.DOMParser;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -34,8 +33,6 @@ import org.xml.sax.SAXException;
  */
 public class DefaultDOMSource extends DOMSource
 {
-    static boolean neko_fixed = false;
-
     public DefaultDOMSource(DocumentSource src)
     {
         super(src);
@@ -44,18 +41,6 @@ public class DefaultDOMSource extends DOMSource
     @Override
     public Document parse() throws SAXException, IOException
     {
-        //temporay NekoHTML fix until nekohtml gets fixed
-        if (!neko_fixed)
-        {
-            HTMLElements.Element li = HTMLElements.getElement(HTMLElements.LI);
-            HTMLElements.Element[] oldparents = li.parent;
-            li.parent = new HTMLElements.Element[oldparents.length + 1];
-            for (int i = 0; i < oldparents.length; i++)
-                li.parent[i] = oldparents[i];
-            li.parent[oldparents.length] = HTMLElements.getElement(HTMLElements.MENU);
-            neko_fixed = true;
-        }
-        
         DOMParser parser = new DOMParser(new HTMLConfiguration());
         parser.setProperty("http://cyberneko.org/html/properties/names/elems", "lower");
         if (charset != null)


### PR DESCRIPTION
DoS attack valunerbility CVE-2022-28366 and CVE-2022-28366 are reported on CyberNeko(net.sourceforge.nekohtml) and its forks. A project 'org.codelibs:nekohtml:*' we use does not fix the issue yet.

HTMLUnit team maintains neko project actively and it fixed the issue.

A proposal here to switch to 'org.htmlunit:neko-htmlunit:3.6.0'.