### PR TITLE
Properly escape contents of text nodes and use self-closing tags for empty nodes

### DIFF
--- a/src/main/java/org/fit/cssbox/css/NormalOutput.java
+++ b/src/main/java/org/fit/cssbox/css/NormalOutput.java
@@ -25,6 +25,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 
+import org.unbescape.html.HtmlEscape;
 import org.w3c.dom.*;
 
 /**
@@ -105,12 +106,18 @@ public class NormalOutput extends Output
                 Node attr = attrs.item(i);
                 tag = tag + " " + attr.getNodeName() + "=\"" + attr.getNodeValue() + "\"";
             }
+            if (n.getChildNodes().getLength() == 0) {
+                // Use self-closing tag for empty node
+                tag = tag + "/>";
+                p.print(tag);
+                return;
+            }
             tag = tag + ">";
             p.print(tag);
         }
         else if (n.getNodeType() == Node.TEXT_NODE)
         {
-            p.print(n.getNodeValue());
+            p.print(HtmlEscape.escapeHtml4Xml(n.getNodeValue()));
         }
         else if (n.getNodeType() == Node.COMMENT_NODE)
         {
@@ -150,6 +157,13 @@ public class NormalOutput extends Output
                 Node attr = attrs.item(i);
                 tag = tag + " " + attr.getNodeName() + "=\"" + attr.getNodeValue() + "\"";
             }
+            if (n.getChildNodes().getLength() == 0) {
+                // Use self-closing tag for empty node
+                tag = tag + "/>";
+                indent(level, p);
+                p.print(tag);
+                return;
+            }
             tag = tag + ">";
             indent(level, p);
             p.println(tag);
@@ -157,7 +171,7 @@ public class NormalOutput extends Output
         else if (n.getNodeType() == Node.TEXT_NODE)
         {
             indent(level, p);
-            p.println(n.getNodeValue());
+            p.print(HtmlEscape.escapeHtml4Xml(n.getNodeValue()));
         }
         else if (n.getNodeType() == Node.COMMENT_NODE)
         {


### PR DESCRIPTION
The NormalOutput class did not properly escape the contents of text nodes (see #71) and used the two tags instead of one for empty nodes (which causes some problems with non-compliant browsers that renders `<br></br>` as two line-breaks).